### PR TITLE
Use the "Path" entry

### DIFF
--- a/dex
+++ b/dex
@@ -370,13 +370,18 @@ class Application(DesktopEntry):
 			_exec = False
 
 		if _exec:
+			path = self.Path
 			cmd = self._build_cmd(self.Exec)
 			if not cmd:
 				raise ApplicationExecException('Failed to build command string.')
 			if dryrun or verbose:
+				if path:
+					print 'Changing directory to: ' + path
 				print 'Executing command: ' + ' '.join(cmd)
 			if dryrun:
 				return None
+			if path:
+				return subprocess.Popen(cmd, cwd=path)
 			return subprocess.Popen(cmd)
 
 class AutostartFile(Application):


### PR DESCRIPTION
The Path entry is not taken into account by dex. The specification says "Path: If entry is of type Application, the working directory to run the program in."
