### PR TITLE
man/conf.py: Turn utf-8 string into Unicode string literal

### DIFF
--- a/man/conf.py
+++ b/man/conf.py
@@ -11,5 +11,5 @@ source_suffix = '.rst'
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('dex', 'dex', 'DesktopEntry Execution',
-     ['Jan Christoph Ebersbach', 'Johannes Löthberg'], 1)
+     ['Jan Christoph Ebersbach', u'Johannes Löthberg'], 1)
 ]


### PR DESCRIPTION
Python2 has broken string handling, so when running sphinx-build under
python2 instead of python3 strings containing UTF-8 characters need to
be Unicode string literals.

Fixes #23