### PR TITLE
Makefile: add force to clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ source: dex man/dex.1 README.rst LICENSE Makefile CHANGELOG.md
 	@rm -rf $(TAG)
 
 clean:
-	@rm $(TAG).tar.gz
-	@rm man/dex.1
+	@rm -f $(TAG).tar.gz
+	@rm -f man/dex.1
 
 .PHONY: build install tgz source clean


### PR DESCRIPTION
Add the -f flag to the rm invocations in the clean target so clean
doesn't fail if one of the files doesn't exist.