### PR TITLE
Makefile: always use configured $(NAME) instead of hard-coded name 'dex'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PREFIX = /usr/local
 DOCPREFIX = $(PREFIX)/share/doc/$(NAME)
 MANPREFIX = $(PREFIX)/man
 VERSION = $(shell git tag | tail -n 1)
-TAG = dex-$(VERSION)
+TAG = $(NAME)-$(VERSION)
 
 build: man/dex.1
 
@@ -14,13 +14,13 @@ man/dex.1: man/dex.rst
 install: dex man/dex.1 README.rst LICENSE
 	@echo installing executable file to $(DESTDIR)$(PREFIX)/bin
 	@mkdir -p $(DESTDIR)$(PREFIX)/bin
-	@install -m 0755 $< $(DESTDIR)$(PREFIX)/bin/
+	@install -m 0755 $< $(DESTDIR)$(PREFIX)/bin/$(NAME)
 	@echo installing docs to $(DESTDIR)$(DOCPREFIX)
 	@mkdir -p $(DESTDIR)$(DOCPREFIX)
 	@install -m 0644 -t $(DESTDIR)$(DOCPREFIX)/ README.rst LICENSE
 	@echo installing manual page to $(DESTDIR)$(MANPREFIX)/man1
 	@mkdir -p $(DESTDIR)$(MANPREFIX)/man1
-	@install -m 0644 -t $(DESTDIR)$(MANPREFIX)/man1 man/dex.1
+	@install -m 0644 man/dex.1 $(DESTDIR)$(MANPREFIX)/man1/$(NAME).1
 
 tgz: source
 


### PR DESCRIPTION
This allows to install dex under a different name.

This resolves issues with conflicting files with the dex text editor, which also provides a dex binary.
