### PR TITLE
Print nice error when target directory does not exist

### DIFF
--- a/dex
+++ b/dex
@@ -740,7 +740,12 @@ def _create(args):
 
 	if args.verbose:
 		print('Output: %s' % output)
-	targetfile = sys.stdout if output == '-' else open(output, 'w')
+
+	try:
+		targetfile = sys.stdout if output == '-' else open(output, 'w')
+	except FileNotFoundError:
+		print('Target directory does not exist: %s' % os.path.dirname(output))
+		return 1
 	de.write(targetfile)
 
 	if args.targetdir and len(args.create) > 1:


### PR DESCRIPTION
Ran into non-existent `~/.config/autostart` dir on new installation. This prints nice error.
```
lasers~ dex -t /tmp/fakedir -c /usr/bin/arandr
Traceback (most recent call last):
  File "/usr/bin/dex", line 786, in <module>
    sys.exit(args.func(args))
  File "/usr/bin/dex", line 743, in _create
    targetfile = sys.stdout if output == '-' else open(output, 'w')
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/fakedir/arandr.desktop'
```
```
lasers~ ~/src/dex/dex -t /tmp/fakedir -c /usr/bin/arandr
Target directory does not exist: /tmp/fakedir
```
I thought about making a directory automatically, but I feel that typos are easy thing to make when experimenting with dex and we only want to use dex to create DesktopEntry files, not directories.