### PR TITLE
Add --term option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,10 @@ Options
 +------------------------------------+------------------------------------------------------------+
 | -t, --target-directory ENVIRONMENT | Create files in target directory                           |
 +------------------------------------+------------------------------------------------------------+
+| --term TERM                        | The terminal emulator that will be used to run the program |
+|                                    | if Terminal=true is set in the desktop file, defaults to   |
+|                                    | x-terminal-emulator.                                       |
++------------------------------------+------------------------------------------------------------+
 | --test                             | Perform a self-test                                        |
 +------------------------------------+------------------------------------------------------------+
 | -v, --verbose                      | Verbose output                                             |
@@ -74,3 +78,7 @@ Create a DesktopEntry for a programs in autostart directroy.
 Execute a single program from command line and enable verbose output.
 
        ``dex -v skype.desktop``
+
+Execute a single program (with Terminal=true in the desktop file) in gnome-terminal.
+
+        ``dex --term gnome-terminal nvim.desktop``

--- a/dex
+++ b/dex
@@ -371,7 +371,7 @@ class Application(DesktopEntry):
 		return self._basename
 
 	@classmethod
-	def _build_cmd(cls, exec_string, needs_terminal=False):
+	def _build_cmd(cls, exec_string, needs_terminal=False, term='x-terminal-emulator'):
 		"""
 		# test single and multi argument commands
 		>>> Application._build_cmd('gvim')
@@ -437,7 +437,7 @@ class Application(DesktopEntry):
 		"""
 		cmd = []
 		if needs_terminal:
-			cmd += ['x-terminal-emulator', '-e']
+			cmd += [term, '-e']
 		_tmp = exec_string.replace('\\\\', '\\')
 		_arg = ''
 		in_esc = False
@@ -502,7 +502,7 @@ class Application(DesktopEntry):
 
 		return cmd
 
-	def execute(self, dryrun=False, verbose=False):
+	def execute(self, term=None, dryrun=False, verbose=False):
 		"""
 		Execute application
 		@return	Return subprocess.Popen object
@@ -514,7 +514,7 @@ class Application(DesktopEntry):
 
 		if _exec:
 			path = self.Path
-			cmd = self._build_cmd(self.Exec)
+			cmd = self._build_cmd(exec_string=self.Exec, needs_terminal=self.Terminal, term=term)
 			if not cmd:
 				raise ApplicationExecException('Failed to build command string.')
 			if dryrun or verbose:
@@ -707,7 +707,7 @@ def _run(args):
 		for f in args.files:
 			try:
 				app = Application(f)
-				app.execute(dryrun=args.dryrun, verbose=args.verbose)
+				app.execute(term=args.term, dryrun=args.dryrun, verbose=args.verbose)
 			except ValueError as ex:
 				print(ex, file=sys.stderr)
 			except IOError as ex:
@@ -769,12 +769,13 @@ if __name__ == '__main__':
 	run.add_argument("-d", "--dry-run", action="store_true", dest="dryrun", help="dry run, don't execute any command")
 	run.add_argument("-e", "--environment", nargs=1, dest="environment", help="specify the Desktop Environment an autostart should be performed for; works only in combination with --autostart")
 	run.add_argument("-s", "--search-paths", nargs=1, dest="searchpaths", help="colon separated list of paths to search for desktop files, overriding the default search list")
+	run.add_argument("--term", dest="term", help="the terminal emulator that will be used to run the program if Terminal=true is set in the desktop file, defaults to x-terminal-emulator")
 
 	create = parser.add_argument_group('create')
 	create.add_argument("-c", "--create", nargs='+', dest="create", help="create a DesktopEntry file for the given program. If a second argument is provided it's taken as output filename or written to stdout (filname: -). By default a new file with the postfix .desktop is created")
 	create.add_argument("-t", "--target-directory", nargs=1, dest="targetdir", help="create files in target directory")
 
-	parser.set_defaults(func=_run, dryrun=False, test=False, autostart=False, verbose=False)
+	parser.set_defaults(func=_run, term="x-terminal-emulator", dryrun=False, test=False, autostart=False, verbose=False)
 
 	args = parser.parse_args()
 	if args.autostart:

--- a/man/dex.rst
+++ b/man/dex.rst
@@ -35,6 +35,9 @@ Options
 -t DIRECTORY, --target-directory DIRECTORY
         Create files in target directory
 
+--term TERM
+        The terminal emulator that will be used to run the program if Terminal=true is set in the desktop file, defaults to x-terminal-emulator
+
 --test
         Perform a self-test
 
@@ -74,3 +77,7 @@ Create a DesktopEntry for a programs in autostart directory.
 Execute a single program from command line and enable verbose output.
 
         :program:`dex -v skype.desktop`
+
+Execute a single program (with Terminal=true in the desktop file) in gnome-terminal.
+
+        :program:`dex --term gnome-terminal nvim.desktop`


### PR DESCRIPTION
The `--term` option allows the user to choose the terminal emulator that
will be used when running a desktop file with `Terminal=true` set.

The default is `x-terminal-emulator`.

Example:
```bash
dex --term alacritty /usr/share/applications/nvim.desktop
```

Solves: #33