### PR TITLE
Add --wait option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,8 @@ Options
 |                                    | if Terminal=true is set in the desktop file, defaults to   |
 |                                    | x-terminal-emulator.                                       |
 +------------------------------------+------------------------------------------------------------+
+| -w, --wait                         | Block until the program exits.                             |
++------------------------------------+------------------------------------------------------------+
 | --test                             | Perform a self-test                                        |
 +------------------------------------+------------------------------------------------------------+
 | -v, --verbose                      | Verbose output                                             |
@@ -82,3 +84,7 @@ Execute a single program from command line and enable verbose output.
 Execute a single program (with Terminal=true in the desktop file) in gnome-terminal.
 
         ``dex --term gnome-terminal nvim.desktop``
+
+Execute a single program and block until it exits.
+
+        ``dex --wait nvim.desktop``

--- a/dex
+++ b/dex
@@ -502,7 +502,7 @@ class Application(DesktopEntry):
 
 		return cmd
 
-	def execute(self, term=None, dryrun=False, verbose=False):
+	def execute(self, term=None, wait=False, dryrun=False, verbose=False):
 		"""
 		Execute application
 		@return	Return subprocess.Popen object
@@ -525,9 +525,12 @@ class Application(DesktopEntry):
 				print('Executing command: ' + ' '.join(cmd))
 			if dryrun:
 				return None
+			_execute_fn = subprocess.Popen
+			if wait:
+				_execute_fn = subprocess.call
 			if path:
-				return subprocess.Popen(cmd, cwd=path)
-			return subprocess.Popen(cmd)
+				return _execute_fn(cmd, cwd=path)
+			return _execute_fn(cmd)
 
 
 class AutostartFile(Application):
@@ -707,7 +710,7 @@ def _run(args):
 		for f in args.files:
 			try:
 				app = Application(f)
-				app.execute(term=args.term, dryrun=args.dryrun, verbose=args.verbose)
+				app.execute(term=args.term, wait=args.wait, dryrun=args.dryrun, verbose=args.verbose)
 			except ValueError as ex:
 				print(ex, file=sys.stderr)
 			except IOError as ex:
@@ -770,12 +773,13 @@ if __name__ == '__main__':
 	run.add_argument("-e", "--environment", nargs=1, dest="environment", help="specify the Desktop Environment an autostart should be performed for; works only in combination with --autostart")
 	run.add_argument("-s", "--search-paths", nargs=1, dest="searchpaths", help="colon separated list of paths to search for desktop files, overriding the default search list")
 	run.add_argument("--term", dest="term", help="the terminal emulator that will be used to run the program if Terminal=true is set in the desktop file, defaults to x-terminal-emulator")
+	run.add_argument("-w", "--wait", action="store_true", dest="wait", help="block until the program exits")
 
 	create = parser.add_argument_group('create')
 	create.add_argument("-c", "--create", nargs='+', dest="create", help="create a DesktopEntry file for the given program. If a second argument is provided it's taken as output filename or written to stdout (filname: -). By default a new file with the postfix .desktop is created")
 	create.add_argument("-t", "--target-directory", nargs=1, dest="targetdir", help="create files in target directory")
 
-	parser.set_defaults(func=_run, term="x-terminal-emulator", dryrun=False, test=False, autostart=False, verbose=False)
+	parser.set_defaults(func=_run, term="x-terminal-emulator", wait=False, dryrun=False, test=False, autostart=False, verbose=False)
 
 	args = parser.parse_args()
 	if args.autostart:

--- a/man/dex.rst
+++ b/man/dex.rst
@@ -38,6 +38,9 @@ Options
 --term TERM
         The terminal emulator that will be used to run the program if Terminal=true is set in the desktop file, defaults to x-terminal-emulator
 
+-w, --wait
+        Block until the program exits
+
 --test
         Perform a self-test
 
@@ -81,3 +84,7 @@ Execute a single program from command line and enable verbose output.
 Execute a single program (with Terminal=true in the desktop file) in gnome-terminal.
 
         :program:`dex --term gnome-terminal nvim.desktop`
+
+Execute a single program and block until it exits.
+
+        :program:`dex --wait nvim.desktop`


### PR DESCRIPTION
The --wait option causes dex to wait for the application process to end
before exiting. Without the option set, the default behavior is to exit immediately.

Example:
```bash
dex --wait /usr/share/applications/nvim.desktop
```

This option allows, for example, to run a desktop file from the [sway](https://github.com/swaywm/sway) compositor and save the application's output to the sway log.

```bash
swaymsg exec "dex --wait /usr/share/applications/nvim.desktop"
```
