### PR TITLE
[Feature Request] Added support for retrieving property values and fixed some typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,11 @@ Options
 | -e, --environment ENVIRONMENT      | Specify the Desktop Environment an autostart should be     |
 |                                    | performed for; works only in combination with -a           |
 +------------------------------------+------------------------------------------------------------+
+| -p PROPERTY, --property PROPERTY   | Display DesktopEntry property value. Supported properties  |
+|                                    | are: Type, Version, Name, NoDisplay, Hidden, OnlyShowIn,   |
+|                                    | NotShowIn, TryExec, Exec, Path, Terminal, StartupNotify,   |
+|                                    | StartupWMClass, URL                                        |
++------------------------------------+------------------------------------------------------------+
 | -s, --search-paths SEARCHPATHS     | Colon separated list of paths to search for desktop files, |
 |                                    | overriding the default search list                         |
 +------------------------------------+------------------------------------------------------------+
@@ -68,6 +73,10 @@ Preview the programs would be executed in a regular autostart.
 Preview the programs would be executed in a GNOME specific autostart.
 
        ``dex -ad -e GNOME``
+
+Preview the value of DesktopEntry property Name.
+
+       ``dex -p Name htop.desktop``
 
 Create a DesktopEntry for a program in the current directory.
 

--- a/dex
+++ b/dex
@@ -35,7 +35,7 @@ import os
 import subprocess
 import sys
 
-__version__ = "0.8.0"
+__version__ = "0.9.1"
 
 
 # DesktopEntry exceptions
@@ -691,7 +691,7 @@ def _autostart(args):
 			app.execute(dryrun=args.dryrun, verbose=args.verbose)
 		except Exception as ex:
 			exit_value = 1
-			print("Execution faild: %s%s%s" % (app.filename, os.linesep, ex), file=sys.stderr)
+			print("Execution failed: %s%s%s" % (app.filename, os.linesep, ex), file=sys.stderr)
 
 
 def _run(args):
@@ -717,7 +717,7 @@ def _run(args):
 				print(ex, file=sys.stderr)
 			except Exception as ex:
 				exit_value = 1
-				print("Execution faild: %s%s%s" % (f, os.linesep, ex), file=sys.stderr)
+				print("Execution failed: %s%s%s" % (f, os.linesep, ex), file=sys.stderr)
 	return exit_value
 
 
@@ -756,6 +756,50 @@ def _create(args):
 		return _create(args)
 	return 0
 
+def _property(args):
+	"""
+	Display DesktopEntry property value
+	"""
+	exit_value = 0
+	if not args.files:
+		print("Nothing to parse, no DesktopEntry files specified!", file=sys.stderr)
+		parser.print_help()
+		exit_value = 1
+	else:
+		properties = (
+			'Type',
+			'Version',
+			'Name',
+			'NoDisplay',
+			'Hidden',
+			'OnlyShowIn',
+			'NotShowIn',
+			'TryExec',
+			'Exec',
+			'Path',
+			'Terminal',
+			'StartupNotify',
+			'StartupWMClass',
+			'URL'
+		)
+		property = args.property[0]
+		for f in args.files:
+			try:
+				app = Application(f)
+				if property in properties:
+					print(getattr(app, property))
+				else:
+					exit_value = 1
+					print("'%s' is not a valid Desktop Entry property." % property, file=sys.stderr)
+			except ValueError as ex:
+				print(ex, file=sys.stderr)
+			except IOError as ex:
+				print(ex, file=sys.stderr)
+			except Exception as ex:
+				exit_value = 1
+				print("Parse failed: %s%s%s" % (f, os.linesep, ex), file=sys.stderr)
+	return exit_value
+
 
 # start execution
 if __name__ == '__main__':
@@ -766,6 +810,9 @@ if __name__ == '__main__':
 	parser.add_argument("-v", "--verbose", action="store_true", dest="verbose", help="verbose output")
 	parser.add_argument("-V", "--version", action="store_true", dest="version", help="display version information")
 	parser.add_argument('files', nargs='*', help="DesktopEntry files")
+
+	property = parser.add_argument_group('property')
+	property.add_argument("-p", "--property", nargs=1, dest="property", help="display DesktopEntry property value. Supported properties are: Type, Version, Name, NoDisplay, Hidden, OnlyShowIn, NotShowIn, TryExec, Exec, Path, Terminal, StartupNotify, StartupWMClass, URL")
 
 	run = parser.add_argument_group('run')
 	run.add_argument("-a", "--autostart", action="store_true", dest="autostart", help="autostart programs")
@@ -788,6 +835,8 @@ if __name__ == '__main__':
 		args.func = _create
 	elif args.test:
 		args.func = _test
+	elif args.property:
+		args.func = _property
 
 	# display version information
 	if args.version:

--- a/dex
+++ b/dex
@@ -35,7 +35,7 @@ import os
 import subprocess
 import sys
 
-__version__ = "0.9.1"
+__version__ = "0.10.1"
 
 
 # DesktopEntry exceptions

--- a/man/dex.rst
+++ b/man/dex.rst
@@ -24,7 +24,7 @@ Options
         Create a DesktopEntry file for the program at the given path. An optional second argument is used to specify the filename of the created DesktopEntry file, or specify the filename - to print the file to stdout. By default a new file is created with the .desktop file extension.
 
 -d, --dry-run
-        Dry run, dont execute any command
+        Dry run, don't execute any command
 
 -e ENVIRONMENT, --environment ENVIRONMENT
         Specify the Desktop Environment an autostart should be performed for; works only in combination with --autostart

--- a/man/dex.rst
+++ b/man/dex.rst
@@ -24,10 +24,13 @@ Options
         Create a DesktopEntry file for the program at the given path. An optional second argument is used to specify the filename of the created DesktopEntry file, or specify the filename - to print the file to stdout. By default a new file is created with the .desktop file extension.
 
 -d, --dry-run
-        Dry run, don't execute any command
+        Dry run, dont execute any command
 
 -e ENVIRONMENT, --environment ENVIRONMENT
         Specify the Desktop Environment an autostart should be performed for; works only in combination with --autostart
+
+-p PROPERTY, --property PROPERTY
+        Display DesktopEntry property value. Supported properties are: Type, Version, Name, NoDisplay, Hidden, OnlyShowIn, NotShowIn, TryExec, Exec, Path, Terminal, StartupNotify, StartupWMClass, URL
 
 -s SEARCHPATHS, --search-paths SEARCHPATHS
         Colon separated list of paths to search for desktop files, overriding the default search list
@@ -68,6 +71,10 @@ Preview the programs would be executed in a regular autostart.
 Preview the programs would be executed in a GNOME specific autostart.
 
         :program:`dex -ad -e GNOME`
+
+Preview the value of DesktopEntry property Name.
+
+        :program:`dex -p Name htop.desktop`
 
 Create a DesktopEntry for a program in the current directory.
 


### PR DESCRIPTION
### Edit

This has taken inspiration from the [dpkg-parsechangelog(1)](https://manpages.debian.org/buster/dpkg-dev/dpkg-parsechangelog.1.en.html#OPTIONS), specifically, the `--show-field` option of it which displays the value of a field defined in a Debian [changelog](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog) file. The implementation was rather rushed, but it represents the logic that I wanted. Please reimplement the whole thing in the right manner.

### What's included in this change:

* Added support for retrieving DesktopEntry property values defined in the [DesktopEntry](https://github.com/jceb/dex/blob/617bb29c0e6dfcb33fb7330a8b88e34461c2f905/dex#L60) class (useful for parsing a basic DesktopEntry fields). Currently supported properties includes: Type, Version, Name, NoDisplay, Hidden, OnlyShowIn, NotShowIn, TryExec, Exec, Path, Terminal, StartupNotify, StartupWMClass, URL. Other properties that throws an exception are excluded.
* Fixed typos described in PR #38 and #35.