### PR TITLE
Added `term` argument to `_autostart`

### DIFF
--- a/dex
+++ b/dex
@@ -688,7 +688,7 @@ def _autostart(args):
 	exit_value = 0
 	for app in get_autostart_files(args, verbose=args.verbose):
 		try:
-			app.execute(dryrun=args.dryrun, verbose=args.verbose)
+			app.execute(term=args.term, dryrun=args.dryrun, verbose=args.verbose)
 		except Exception as ex:
 			exit_value = 1
 			print("Execution faild: %s%s%s" % (app.filename, os.linesep, ex), file=sys.stderr)


### PR DESCRIPTION
The `term` argument is now propagated to the function, responsible to
execute files found in autostart folders, so the command line option
`--term` now also works with the `-a` option and not only when directly
executing a specific desktop file.