### PR TITLE
Adding support for XDG_CURRENT_DESKTOP environment variable

### DIFF
--- a/dex
+++ b/dex
@@ -814,7 +814,7 @@ if __name__ == '__main__':
 	run = parser.add_argument_group('run')
 	run.add_argument("-a", "--autostart", action="store_true", dest="autostart", help="autostart programs")
 	run.add_argument("-d", "--dry-run", action="store_true", dest="dryrun", help="dry run, don't execute any command")
-	run.add_argument("-e", "--environment", dest="environment", help="specify the Desktop Environment an autostart should be performed for; works only in combination with --autostart")
+	run.add_argument("-e", "--environment", dest="environment", help="specify the Desktop Environment an autostart should be performed for; works only in combination with --autostart", default=os.environ.get('XDG_CURRENT_DESKTOP'))
 	run.add_argument("-s", "--search-paths", nargs=1, dest="searchpaths", help="colon separated list of paths to search for desktop files, overriding the default search list")
 	run.add_argument("--term", dest="term", help="the terminal emulator that will be used to run the program if Terminal=true is set in the desktop file, defaults to x-terminal-emulator")
 	run.add_argument("-w", "--wait", action="store_true", dest="wait", help="block until the program exits")


### PR DESCRIPTION
PR for issue #59 
The XDG_CURRENT_DESKTOP environment variable is set as the default value for dex `environment` argument. If the variable does not exist, the behavior is consistent the same than before this patch.