### PR TITLE
Add support for "additional application actions"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,9 @@ Options
 +====================================+============================================================+
 | -h, --help                         | Show a help message and exit                               |
 +------------------------------------+------------------------------------------------------------+
+| --action ACTION                    | Identifier of an "additional application action" to        |
+|                                    | operate on. Also known as a quicklist/jumplist entry.      |
++------------------------------------+------------------------------------------------------------+
 | -a, --autostart                    | Autostart programs                                         |
 +------------------------------------+------------------------------------------------------------+
 | -c, --create PATH                  | Create a DesktopEntry file for the program at the given    |
@@ -34,8 +37,9 @@ Options
 +------------------------------------+------------------------------------------------------------+
 | -p PROPERTY, --property PROPERTY   | Display DesktopEntry property value. Supported properties  |
 |                                    | are: Type, Version, Name, NoDisplay, Hidden, OnlyShowIn,   |
-|                                    | NotShowIn, TryExec, Exec, Path, Terminal, StartupNotify,   |
-|                                    | StartupWMClass, URL                                        |
+|                                    | NotShowIn, TryExec, Exec, Path, Terminal, Actions,         |
+|                                    | StartupNotify, StartupWMClass, URL. For ACTIONs, only Name |
+|                                    | and Exec are supported.                                    |
 +------------------------------------+------------------------------------------------------------+
 | -s, --search-paths SEARCHPATHS     | Colon separated list of paths to search for desktop files, |
 |                                    | overriding the default search list                         |
@@ -97,6 +101,10 @@ Execute a single program (with Terminal=true in the desktop file) in gnome-termi
 Execute a single program and block until it exits.
 
         ``dex --wait nvim.desktop``
+
+Execute a specifified application action.
+
+        ``dex --action new-private-window firefox.desktop``
 
 Autostart Alternative
 ---------------------

--- a/dex
+++ b/dex
@@ -314,6 +314,10 @@ class DesktopEntry(object):
 		return self.get_strings('MimeType')
 
 	@property
+	def Actions(self):
+		return self.get_list('Actions')
+
+	@property
 	def Categories(self):
 		return self.get_strings('Categories')
 
@@ -501,9 +505,9 @@ class Application(DesktopEntry):
 
 		return cmd
 
-	def execute(self, term=None, wait=False, dryrun=False, verbose=False):
+	def execute(self, action=None, term=None, wait=False, dryrun=False, verbose=False):
 		"""
-		Execute application
+		Execute application or, if given, a specific action
 		@return	Return subprocess.Popen object
 		"""
 		_exec = True
@@ -513,7 +517,10 @@ class Application(DesktopEntry):
 
 		if _exec:
 			path = self.Path
-			cmd = self._build_cmd(exec_string=self.Exec, needs_terminal=self.Terminal, term=term)
+			_exec_str = self.Exec
+			if action:
+				_exec_str = Action(owner=self, identifier=action).Exec
+			cmd = self._build_cmd(exec_string=_exec_str, needs_terminal=self.Terminal, term=term)
 			if not cmd:
 				raise ApplicationExecException('Failed to build command string.')
 			if dryrun or verbose:
@@ -558,6 +565,31 @@ class EmptyAutostartFile(Application):
 		except DesktopEntryTypeException:
 			# ignore the missing type information
 			pass
+
+
+class Action(object):
+	def __init__(self, owner, identifier):
+		"""
+		@param	owner	The Application that this action is part of
+		@param	identifier	The Desktop Action's identifier (not its Name!)
+		"""
+		self._owner = owner
+		self._id = identifier
+
+	def group_name(self):
+		return "Desktop Action %s" % self._id
+
+	@property
+	def identifier(self):
+		return self._id
+
+	@property
+	def Name(self):
+		return self._owner.get_string('Name', group=self.group_name())
+
+	@property
+	def Exec(self):
+		return self._owner.get_string('Exec', group=self.group_name())
 
 
 # local methods
@@ -693,7 +725,7 @@ def _autostart(args):
 
 def _run(args):
 	"""
-	execute specified DesktopEntry files
+	execute specified DesktopEntry files, or specified action of each file
 	"""
 	if args.dryrun and args.verbose:
 		print('Dry run, nothing is executed.', file=sys.stderr)
@@ -707,7 +739,7 @@ def _run(args):
 		for f in args.files:
 			try:
 				app = Application(f)
-				app.execute(term=args.term, wait=args.wait, dryrun=args.dryrun, verbose=args.verbose)
+				app.execute(action=args.action, term=args.term, wait=args.wait, dryrun=args.dryrun, verbose=args.verbose)
 			except ValueError as ex:
 				print(ex, file=sys.stderr)
 			except IOError as ex:
@@ -775,19 +807,32 @@ def _property(args):
 			'Exec',
 			'Path',
 			'Terminal',
+			'Actions',
 			'StartupNotify',
 			'StartupWMClass',
 			'URL'
+		)
+		action_properties = (
+			'Name',
+			'Exec'
 		)
 		property = args.property[0]
 		for f in args.files:
 			try:
 				app = Application(f)
-				if property in properties:
+
+				allowed_properties = properties
+				error_keyword = "Entry"
+				if args.action:
+					app = Action(owner=app, identifier=args.action)
+					allowed_properties = action_properties
+					error_keyword = "Action"
+
+				if property in allowed_properties:
 					print(getattr(app, property))
 				else:
 					exit_value = 1
-					print("'%s' is not a valid Desktop Entry property." % property, file=sys.stderr)
+					print("'%s' is not a valid Desktop %s property." % (property, error_keyword), file=sys.stderr)
 			except ValueError as ex:
 				print(ex, file=sys.stderr)
 			except IOError as ex:
@@ -803,13 +848,14 @@ if __name__ == '__main__':
 	from argparse import ArgumentParser
 	parser = ArgumentParser(usage='%(prog)s [options] [DesktopEntryFile [DesktopEntryFile ...]]',
 			description='dex, DesktopEntry Execution, is a program to generate and execute DesktopEntry files of the type Application', epilog='Example usage: list autostart programs: dex -ad')
+	parser.add_argument("--action", dest="action", help="identifier of an \"additional application action\" to operate on. Also known as a quicklist/jumplist entry")
 	parser.add_argument("--test", action="store_true", dest="test", help="perform a self-test")
 	parser.add_argument("-v", "--verbose", action="store_true", dest="verbose", help="verbose output")
 	parser.add_argument("-V", "--version", action="store_true", dest="version", help="display version information")
 	parser.add_argument('files', nargs='*', help="DesktopEntry files")
 
 	property = parser.add_argument_group('property')
-	property.add_argument("-p", "--property", nargs=1, dest="property", help="display DesktopEntry property value. Supported properties are: Type, Version, Name, NoDisplay, Hidden, OnlyShowIn, NotShowIn, TryExec, Exec, Path, Terminal, StartupNotify, StartupWMClass, URL")
+	property.add_argument("-p", "--property", nargs=1, dest="property", help="display DesktopEntry property value. Supported properties are: Type, Version, Name, NoDisplay, Hidden, OnlyShowIn, NotShowIn, TryExec, Exec, Path, Terminal, Actions, StartupNotify, StartupWMClass, URL. For ACTIONs, only Name and Exec are supported")
 
 	run = parser.add_argument_group('run')
 	run.add_argument("-a", "--autostart", action="store_true", dest="autostart", help="autostart programs")

--- a/man/dex.rst
+++ b/man/dex.rst
@@ -17,6 +17,9 @@ Options
 -h, --help
         Show this help message and exit
 
+--action ACTION
+        Identifier of an "additional application action" to operate on. Also known as a quicklist/jumplist entry.
+
 -a, --autostart
         Autostart programs
 
@@ -30,7 +33,7 @@ Options
         Specify the Desktop Environment an autostart should be performed for; works only in combination with --autostart
 
 -p PROPERTY, --property PROPERTY
-        Display DesktopEntry property value. Supported properties are: Type, Version, Name, NoDisplay, Hidden, OnlyShowIn, NotShowIn, TryExec, Exec, Path, Terminal, StartupNotify, StartupWMClass, URL
+        Display DesktopEntry property value. Supported properties are: Type, Version, Name, NoDisplay, Hidden, OnlyShowIn, NotShowIn, TryExec, Exec, Path, Terminal, Actions, StartupNotify, StartupWMClass, URL. For ACTIONs, only Name and Exec are supported.
 
 -s SEARCHPATHS, --search-paths SEARCHPATHS
         Colon separated list of paths to search for desktop files, overriding the default search list
@@ -95,3 +98,7 @@ Execute a single program (with Terminal=true in the desktop file) in gnome-termi
 Execute a single program and block until it exits.
 
         :program:`dex --wait nvim.desktop`
+
+Execute a specifified application action.
+
+        :program:`dex --action new-private-window firefox.desktop`


### PR DESCRIPTION
As per the [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s11.html) (since version 1.1), "entries of type Application can include one or more actions. An action represents an additional way to invoke the application."

These commits add support for displaying the supported actions (via the already existing `--property` option) and running a specific action from a desktop file (via the new `--action` option).

Some remarks:
* The specification makes it not entirely clear to me whether properties like `Terminal` from the main application should apply to the additional applications actions. However, this seems to be the sensible choice.
* Furthermore, it says that:
  > It is not valid to have an action group for an action identifier not mentioned in the Actions key. Such an action group must be ignored by implementors.
  
  The current impementation does not fully honor this: Though such an action group is not listed by `--property Actions`, it can still be run via `--action`, as long as its identifier is known. A check could easily be added, however, it seems unnecessary to me and the current ability rather appears as a feature than a problem.